### PR TITLE
Add regression mode

### DIFF
--- a/configs/datamodules/transform/tf_pe_zscore.yaml
+++ b/configs/datamodules/transform/tf_pe_zscore.yaml
@@ -1,13 +1,9 @@
-# Adds random walk positional encodings
+# Adds random walk positional encoding
 # Normalizes edge features using Z-Score
 #
-# Target gets binarized so that all multiplicities values
-# bigger than zero get clamped to one
 _target_: torch_geometric.transforms.compose.Compose
 transforms:
   - _target_: transforms.add_positional_encoding.AddRandomWalkPE
     walk_length: 5
   - _target_: transforms.col_zscore_features.ColZscoreFeatures
     attrs: [edge_attr]
-  - _target_: transforms.binarize_targets.BinarizeTargets
-    attrs: [y]

--- a/configs/experiment/E40_L5_H32_C8.yaml
+++ b/configs/experiment/E40_L5_H32_C8.yaml
@@ -14,11 +14,4 @@ datamodules:
 
 baseline: E${trainer.max_epochs}_L${models.net.num_layers}_H${models.net.hidden_features}_C${datamodules.num_clusters}
 
-ckpt_path: ${paths.storage_dir}/models/${baseline}/best_model.ckpt
-
-loggers:
-  wandb:
-    name: inference_${dataset_name}
-    group: inference_${baseline}_T${models.threshold}
-    tags: ["resgated_mdg"]
-    offline: True
+ckpt_path: #${paths.storage_dir}/models/${baseline}/best_model.ckpt

--- a/configs/experiment/E40_L6_H16_C8.yaml
+++ b/configs/experiment/E40_L6_H16_C8.yaml
@@ -14,11 +14,4 @@ datamodules:
 
 baseline: E${trainer.max_epochs}_L${models.net.num_layers}_H${models.net.hidden_features}_C${datamodules.num_clusters}
 
-ckpt_path: ${paths.storage_dir}/models/${baseline}/best_model.ckpt
-
-loggers:
-  wandb:
-    name: inference_${dataset_name}
-    group: inference_${baseline}_T${models.threshold}
-    tags: ["resgated_mdg"]
-    offline: True
+ckpt_path: #${paths.storage_dir}/models/${baseline}/best_model.ckpt

--- a/configs/inference_cfg.yaml
+++ b/configs/inference_cfg.yaml
@@ -14,3 +14,13 @@ defaults:
 
 # task name, used as output directory path
 task_name: "inference"
+
+# checkpoint path, should rename it to differentiate training/inference
+ckpt_path: ${paths.storage_dir}/models/${baseline}/best_model.ckpt
+# dataset_name and baseline are defined in experiment
+loggers:
+  wandb:
+    name: inference_${dataset_name}
+    group: inference_${baseline}_T${models.threshold}
+    tags: ["resgated_mdg"]
+    offline: False

--- a/configs/models/criterion/focal_loss.yaml
+++ b/configs/models/criterion/focal_loss.yaml
@@ -1,0 +1,4 @@
+_target_: models.loss.focal_loss.FocalLoss
+alpha: 0.25
+gamma: 2
+reduction: mean

--- a/configs/models/criterion/rmse_loss.yaml
+++ b/configs/models/criterion/rmse_loss.yaml
@@ -1,0 +1,2 @@
+_target_: models.loss.rmse_loss.RMSELoss
+reduce: mean

--- a/configs/models/models.yaml
+++ b/configs/models/models.yaml
@@ -3,7 +3,7 @@ defaults:
   - _self_
 
 _target_: models.dbg_light_module.DBGLightningModule
-storage_path: ${paths.output_dir}
+storage_path: #${paths.output_dir}
 
 optimizer:
   _target_: torch.optim.Adam

--- a/configs/models/models.yaml
+++ b/configs/models/models.yaml
@@ -1,5 +1,6 @@
 defaults:
   - net: resgated_multidigraph
+  - criterion: focal_loss
   - _self_
 
 _target_: models.dbg_light_module.DBGLightningModule
@@ -10,10 +11,6 @@ optimizer:
   _partial_: true
   lr: 0.001
   weight_decay: 0.0
-  #_target_: torch.optim.SGD
-  #_partial_: true
-  #lr: 0.001
-  #momentum: 0.9
 
 scheduler:
   _target_: torch.optim.lr_scheduler.ReduceLROnPlateau
@@ -23,19 +20,3 @@ scheduler:
   patience: 2
   min_lr: 1.e-6
   verbose: True
-  #_target_: torch.optim.lr_scheduler.CyclicLR
-  #_partial_: True
-  #mode: triangular
-  #max_lr: 0.01
-  #base_lr: 0.0001
-  #step_size_up: 10
-  #step_size_down: 20
-
-criterion:
-  #_target_: torch.nn.BCEWithLogitsLoss
-  #pos_weight: # Use none for now, perhaps export this as metadata for dataset
-  # _target_: torch.nn.MSELoss
-  _target_: models.loss.focal_loss.FocalLoss
-  alpha: 0.25
-  gamma: 2
-  reduction: mean

--- a/configs/train_cfg.yaml
+++ b/configs/train_cfg.yaml
@@ -15,6 +15,16 @@ defaults:
 
 # task name, used as output directory path
 task_name: "train"
+metadata:
+  graph: multidigraph
+
+# dataset_name and baseline are defined in experiment config
+loggers:
+  wandb:
+    name: train_${dataset_name}
+    group: train_${baseline}_T${models.threshold}
+    tags: ["resgated_mdg"]
+    offline: True
 
 #use False to skip if we should only do the testing
 train: True
@@ -24,3 +34,5 @@ test: True
 
 # we can provide previously trained model here
 ckpt_path: null
+# where do we want to store the best model?
+model_output_path: ${paths.storage_dir}/models/${baseline}/best_model.ckpt

--- a/src/models/loss/rmse_loss.py
+++ b/src/models/loss/rmse_loss.py
@@ -1,0 +1,14 @@
+import torch.nn as nn
+import torch
+from torch import Tensor
+
+
+class RMSELoss(nn.Module):
+    """Root Mean square error."""
+
+    def __init__(self, reduce: str = "mean"):
+        super().__init__()
+        self.mse = nn.MSELoss(reduce=reduce)
+
+    def forward(self, input: Tensor, target: Tensor):
+        return torch.sqrt(self.mse(input, target))


### PR DESCRIPTION
- Fix configs after cleanup
- Add components for regression mode

In order to train in regression mode, use transformation without target
binarization, RMSELoss as criterion and set appropriate offset for
lightning module

Closes #58
