### PR TITLE
Small improvements and fixes

### DIFF
--- a/configs/datamodules/combined_datamodules.yaml
+++ b/configs/datamodules/combined_datamodules.yaml
@@ -1,10 +1,9 @@
 defaults:
   - _self_
-  - datasets@train_datasets: concat_datasets_train.yaml
-  - datasets@val_datasets: concat_datasets_val.yaml
+  - datasets@train_datasets: concat_dataset_train.yaml
+  - datasets@val_datasets: concat_dataset_val.yaml
   - transform: tf_pe_zscore_bin.yaml
 
 _target_: data.combined_dbg_datamodule.CombinedDBGDataModule
 batch_size: 1
 num_workers: 4
-num_clusters: 8

--- a/configs/datamodules/datasets/concat_dataset_val.yaml
+++ b/configs/datamodules/datasets/concat_dataset_val.yaml
@@ -2,12 +2,12 @@ _target_: torch.utils.data.dataset.ConcatDataset
 datasets:
   - _target_: data.cluster_dbg_dataset.ClusteredDBGDataset
     root: ${paths.dataset_dir}/hg002_real_dataset/val
-    transform: ${datasets.transform}
-    num_clusters: 8
+    transform: ${datamodules.transform}
+    num_clusters: 16
   - _target_: data.cluster_dbg_dataset.ClusteredDBGDataset
     root: ${paths.dataset_dir}/chm13_real_dataset/val
-    transform: ${datasets.transform}
+    transform: ${datamodules.transform}
     num_clusters: 8
   - _target_: data.dbg_dataset.DBGDataset
     root: ${paths.dataset_dir}/bed_chm13_dataset/val
-    transform: ${datasets.transform}
+    transform: ${datamodules.transform}

--- a/configs/lja_classification_cfg.yaml
+++ b/configs/lja_classification_cfg.yaml
@@ -23,6 +23,5 @@ train_id: #
 loggers:
   wandb:
     name: inference_${dataset_name}
-    group: inference_${baseline}_T${models.threshold}
+    group: inference_${baseline}
     tags: ["resgated_mdg"]
-    offline: true

--- a/configs/lja_regression_cfg.yaml
+++ b/configs/lja_regression_cfg.yaml
@@ -25,4 +25,3 @@ loggers:
     name: inference_${dataset_name}
     group: inference_${baseline}_T${models.threshold}
     tags: ["resgated_mdg"]
-    offline: true

--- a/configs/train_cfg.yaml
+++ b/configs/train_cfg.yaml
@@ -23,8 +23,7 @@ loggers:
   wandb:
     name: train_${dataset_name}
     group: train_${baseline}_T${models.threshold}
-    tags: ["resgated_mdg"]
-    offline: true
+    tags: ["resgated_mdg", "classification"]
 
 #use False to skip if we should only do the testing
 train: true
@@ -36,6 +35,4 @@ test: false
 ckpt_path: null
 train_id: ${now:%y%m%d%H%M}
 # dir where do we want to store the best model?
-model_output_path: ${paths.storage_dir}/models/${baseline}/${train_id}/
-
-wandb_model_upload: false
+model_output_path: ${paths.storage_dir}/models/class_models/${baseline}/${train_id}/

--- a/configs/train_combined_cfg.yaml
+++ b/configs/train_combined_cfg.yaml
@@ -7,8 +7,8 @@ defaults:
   - loggers: loggers.yaml
   - paths: paths.yaml
   - callbacks: callbacks.yaml
-  - datamodules: datamodules_regression.yaml
-  - models: models_regression.yaml
+  - datamodules: combined_datamodules.yaml
+  - models: models.yaml
   - trainer: trainer_gpu.yaml
   - experiment: null
   - _self_
@@ -21,9 +21,9 @@ metadata:
 # dataset_name and baseline are defined in experiment config
 loggers:
   wandb:
-    name: train_r_${dataset_name}
-    group: train_r_${baseline}
-    tags: ["resgated_mdg", "regression"]
+    name: train_${dataset_name}
+    group: train_${baseline}
+    tags: ["resgated_mdg", "classification"]
 
 #use False to skip if we should only do the testing
 train: true
@@ -33,7 +33,6 @@ test: false
 
 # we can provide previously trained model here
 ckpt_path: null
-# unique identifier of trainining run
 train_id: ${now:%y%m%d%H%M}
 # dir where do we want to store the best model?
-model_output_path: ${paths.storage_dir}/models/regress_models/${baseline}/${train_id}/
+model_output_path: ${paths.storage_dir}/models/class_models/${baseline}/${train_id}/

--- a/configs/train_combined_regression_cfg.yaml
+++ b/configs/train_combined_regression_cfg.yaml
@@ -7,7 +7,7 @@ defaults:
   - loggers: loggers.yaml
   - paths: paths.yaml
   - callbacks: callbacks.yaml
-  - datamodules: datamodules_regression.yaml
+  - datamodules: combined_datamodules.yaml
   - models: models_regression.yaml
   - trainer: trainer_gpu.yaml
   - experiment: null
@@ -23,7 +23,7 @@ loggers:
   wandb:
     name: train_r_${dataset_name}
     group: train_r_${baseline}
-    tags: ["resgated_mdg", "regression"]
+    tags: ["resgated_mdg", "combined_datasets", "regression"]
 
 #use False to skip if we should only do the testing
 train: true

--- a/src/train.py
+++ b/src/train.py
@@ -23,7 +23,7 @@ torch.multiprocessing.set_start_method("spawn", force=True)
 def upload_model_to_wandb(model_path, artifact_name, dataset_name, metadata=None):
     log.info(f"Uploading model {model_path.name} to wandb.")
 
-    run = wandb.init(project=f"chm13-models-{dataset_name}", job_type="add-model")
+    run = wandb.init(project=f"dbg-models-{dataset_name}", job_type="add-model", mode="offline")
 
     artifact = wandb.Artifact(name=artifact_name, type="ml-model", incremental=True, metadata=metadata)
     artifact.add_file(local_path=model_path)
@@ -79,8 +79,7 @@ def train(cfg: DictConfig) -> None:
             if cfg.metadata:
                 metadata.update(dict(cfg.metadata))
 
-            if "wandb_model_upload" in cfg and cfg["wandb_model_upload"]:
-                upload_model_to_wandb(output_file_path, cfg.baseline, cfg.dataset_name, metadata=metadata)
+            upload_model_to_wandb(output_file_path, cfg.baseline, cfg.dataset_name, metadata=metadata)
 
     if cfg.get("test", False):
         log.info("Start testing...")

--- a/test/configs/test_train_config.yaml
+++ b/test/configs/test_train_config.yaml
@@ -15,4 +15,3 @@ defaults:
 
 # task name, used for logging dir name
 task_name: "unittest"
-wandb_model_upload: false

--- a/test/unit/conftest.py
+++ b/test/unit/conftest.py
@@ -101,7 +101,6 @@ def test_train_regress_cfg(test_cfg_root, unittest_ds_path) -> DictConfig:
         f"paths.data_dir={data_dir}",
         "models=test_models_regression",
         "datamodules/transform=test_tf_pe_zscore",
-        "wandb_model_upload=true",
     ]
     with initialize_config_dir(version_base=None, config_dir=str(test_cfg_root)):
         cfg = compose(config_name="test_train_config.yaml", overrides=overrides, return_hydra_config=True)


### PR DESCRIPTION
Closes #99

Performs some smaller config cleanups.

Turns out that the init method of wandb by default runs in the "online" mode
but worker nodes on the cluster do not allow syncing so I need to perform it
manually only after the run has finished. It might be worth considering using
the instantiated logger for wandb that is passed to lightning and use its
method for logging instead of having another run initiated. This way the code
would also have unified config for wandb.
